### PR TITLE
fixes for R-3.5.0-iomkl-2018a-X11-20180131.eb

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.0-iomkl-2018a-X11-20180131.eb
@@ -41,6 +41,7 @@ dependencies = [
     ('NLopt', '2.4.2'),  # for nloptr
     ('FFTW', '3.3.7'),  # for fftw
     ('libsndfile', '1.0.28'),  # for seewave
+    ('ICU', '61.1'),  # for rJava & gdsfmt
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),
@@ -66,7 +67,7 @@ exts_default_options = {
 }
 
 # !! order of packages is important !!
-# packages updated on Mar 15 2018
+# packages updated on June 20 2018
 exts_list = [
     'base',
     'datasets',
@@ -126,7 +127,7 @@ exts_list = [
     ('formatR', '1.5', {
         'checksums': ['874c197ae3720ec11b44984a055655b99a698e1912104eb9034c11fdf6104da7'],
     }),
-    ('gtools', version, {
+    ('gtools', '3.5.0', {
         'checksums': ['86b6a51a92ddb3c78095e0c5dc20414c67f6e28f915bf0ee11406adad3e476f6'],
     }),
     ('gdata', '2.18.0', {
@@ -636,12 +637,8 @@ exts_list = [
     ('blob', '1.1.1', {
         'checksums': ['accbf9c9746c983e4108c8709995e54e61611ea7e2c51d4b6a0d813261484f53'],
     }),
-    ('RSQLite', '2.0', {
-        'patches': ['RSQLite-2.0-icc.patch'],
-        'checksums': [
-            '7f0fe629f34641c6af1e8a34412f3089ee2d184853843209d97ffe29430ceff6',  # RSQLite_2.0.tar.gz
-            '828dd9aeb4f8aaff7bccb8671bee757b8001e049ed349d655044e9c916d1860d',  # RSQLite-2.0-icc.patch
-        ],
+    ('RSQLite', '2.1.1', {
+        'checksums': ['dfdc7de4f453efeed8361b7bec271a9ed7f0c00110e93c24f486e93206993cbe'],
     }),
     ('data.table', '1.11.4', {
         'checksums': ['fdccf1dec3f38bb344163163decf3ffa0c0f8e2c70daa1bec8aac422716e81d5'],
@@ -1131,7 +1128,11 @@ exts_list = [
         'checksums': ['c13ef1b6258e34ba53615b78f39dbe4d8ba47b976b3c24a3eedaecf5ffba19ed'],
     }),
     ('matrixStats', '0.53.1', {
-        'checksums': ['df70bc9fb64716a7a633b5d0c2a2422b2c8d93ac5e64574528a325505df9712e'],
+        'patches': ['matrixStats-0.53.1_O1.patch'],
+        'checksums': [
+            'df70bc9fb64716a7a633b5d0c2a2422b2c8d93ac5e64574528a325505df9712e',  # matrixStats_0.53.1.tar.gz
+            '96ef21a1d5ee4ccd1f4a6b74ef5aa2699a52c38b34613d8ff9f3c4af952aa8fd',  # matrixStats-0.53.1_O1.patch
+        ],
     }),
     ('DiscriMiner', '0.1-29', {
         'checksums': ['5aab7671086ef9940e030324651976456f0e84dab35edb7048693ade885228c6'],
@@ -1468,7 +1469,7 @@ exts_list = [
         'checksums': ['c007d6eaf6335a15c1912b0804276ff39abce27b7a61539a91b8fda653629252'],
     }),
     ('penalized', '0.9-50', {
-        'checksums': ['66ed84b967f70fd49702318e43e129c2ff60bb0631b81fe2617671d1ebbbc060'],
+        'checksums': ['c12b3259e019f91c7bd02827ea3a27f842d9c15950fa6cc114dff23c89c297d1'],
     }),
     ('clusterRepro', '0.5-1.1', {
         'checksums': ['b7fcb9db0c762a2e6e22a0a0689affd73504c56f13c13b04272a946630334e6f'],
@@ -1589,10 +1590,10 @@ exts_list = [
         'checksums': ['2d45ddd1ee0eb7482d5d4a9cfe41b3aa645de8af89295b4b205d73b19ac6d821'],
     }),
     ('imager', '0.41.1', {
-        'patches': ['imager-0.40.2_icpc-wd308.patch'],
+        'patches': ['imager-0.41.1_icpc-wd308.patch'],
         'checksums': [
             'afb42fdd3f62c41007eafa205f671cc4af6d165dc813a7cac194124251bc4849',  # imager_0.41.1.tar.gz
-            'c17ee601d73217a8c177924782f4f6537b3188ff54f4627a521974d07f3870c5',  # imager-0.40.2_icpc-wd308.patch
+            '3e314bf545c40adfeb62a1aff6895e45083e8c9541116f9e771b16bc943451bf',  # imager-0.41.1_icpc-wd308.patch
         ],
     }),
     ('signal', '0.7-6', {
@@ -1868,6 +1869,9 @@ exts_list = [
     }),
     ('gapfill', '0.9.6', {
         'checksums': ['850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d'],
+    }),
+    ('gee', '4.13-19', {
+        'checksums': ['ebd3eb754b338dc8d89a35fff149af57c1be3aa2eb6162912c7cc52a8572c292'],
     }),
 ]
 

--- a/easybuild/easyconfigs/r/R/imager-0.41.1_icpc-wd308.patch
+++ b/easybuild/easyconfigs/r/R/imager-0.41.1_icpc-wd308.patch
@@ -1,0 +1,23 @@
+add -wd308 compiler option to avoid compiler warning #308 being treated as an error
+author: Kenneth Hoste (HPC-UGent)
+diff -ru imager.orig/MD5 imager/MD5
+--- imager.orig/MD5	2018-05-30 09:55:35.000000000 +0200
++++ imager/MD5	2018-06-21 11:24:17.567989939 +0200
+@@ -195,7 +195,7 @@
+ ad2654de31942fed6a81372ca95c69f8 *man/warp.Rd
+ 175e0ff835838c3a97f4e262ea2e22a9 *man/watershed.Rd
+ 6d2ea6da4b089e34b2c74fa9915598ad *man/where.Rd
+-990a6b7a1e785bb41feb36d38ff4c1c4 *src/Makevars.in
++cc2b3acd74abc04e19be54ac6c2451e3 *src/Makevars.in
+ 0921c95e100ceb6edfe481db8258741c *src/Makevars.win
+ 57e4656745ba760e96d3e16920daaca5 *src/RcppExports.cpp
+ cac489a7495799d378cf0c10c8db3ebd *src/colourspace.cpp
+diff -ru imager.orig/src/Makevars.in imager/src/Makevars.in
+--- imager.orig/src/Makevars.in	2018-05-30 09:24:21.000000000 +0200
++++ imager/src/Makevars.in	2018-06-21 11:23:52.987752396 +0200
+@@ -1,3 +1,5 @@
+ PKG_CPPFLAGS = $(OPENMP_CXXFLAGS) @CPPFLAGS@ @HAVE_FFTW@ @FFTW_CFLAGS@ @TIFF_CFLAGS@ -I../inst/include -DCIMG_COMPILING -Dcimg_use_rng -Dcimg_use_r -Dcimg_use_fftw3_singlethread -Dcimg_verbosity=1 -Dcimg_date='""' -Dcimg_time='""'
+ PKG_LIBS =  $(OPENMP_CXXFLAGS) @LIBS@  @HAVE_FFTW@ @FFTW_LIBS@ @TIFF_LIBS@ $(RCPP_LDFLAGS)
+ 
++# disable Intel C++ compiler (icpc) warning/error #308, to avoid 'member "std::complex<double>::_M_value" is inaccessible'
++PKG_CXXFLAGS = -wd308


### PR DESCRIPTION
@edmondac changes applied on top of https://github.com/easybuilders/easybuild-easyconfigs/pull/6466

* add missing ICU dep
* bump RSQLite to 2.1.1 & drop unneeded patch
* add patch for matrixStats
* fix checksum for penalized
* update patch for imager
* add gee extension

@edmondac I tested this whole easyconfig, works like a charm for me...