### PR TITLE
Changed CUDA_HOME and CUDA_ROOT to modextrapaths.

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-9.2.88-1-ppc64le.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-9.2.88-1-ppc64le.eb
@@ -28,10 +28,7 @@ postinstallcmds = [
 
 modextrapaths = {
     'LD_LIBRARY_PATH': ('targets/ppc64le-linux/lib', 'extras/CUPTI/lib64'),
-    'LIBRARY_PATH': 'lib64'
-}
-
-modextravars = {
+    'LIBRARY_PATH': 'lib64',
     'CUDA_HOME': '',
     'CUDA_ROOT': '',
 }


### PR DESCRIPTION
I'm also wondering if the -1 in the version number needs to be there as I think this only relates to the rpm release (which I seems to remember as always being 1 for cuda).